### PR TITLE
added date range

### DIFF
--- a/DT.iOS.DatePickerDialog/DatePickerDialog.cs
+++ b/DT.iOS.DatePickerDialog/DatePickerDialog.cs
@@ -28,6 +28,8 @@ namespace DT.iOS.DatePickerDialog
         private String _doneButtonTitle;
         private String _cancelButtonTitle;
         private DateTime _defaultDate;
+        private DateTime? _maximumDate;
+        private DateTime? _minimumDate;
         private UIDatePickerMode _datePickerMode;
         private Action<DateTime> _callback;
 
@@ -36,12 +38,17 @@ namespace DT.iOS.DatePickerDialog
         {
         }
 
+        public void Show(String title, Action<DateTime> callback, DateTime maximumDate, DateTime minimumDate)
+        {
+            Show(title, doneButtonTitle: "Done", cancelButtonTitle: "Cancel", datePickerMode: UIDatePickerMode.DateAndTime, callback: callback, defaultDate: DateTime.Now, maximumDate: maximumDate,minimumDate: minimumDate);
+        }
+
         public void Show(String title, Action<DateTime> callback, UIDatePickerMode datePickerMode = UIDatePickerMode.DateAndTime)
         {
             Show(title, doneButtonTitle: "Done", cancelButtonTitle: "Cancel", datePickerMode: datePickerMode, callback: callback, defaultDate: DateTime.Now);
         }
 
-        public void Show(string title, string doneButtonTitle, string cancelButtonTitle, UIDatePickerMode datePickerMode, Action<DateTime> callback, DateTime defaultDate)
+        public void Show(string title, string doneButtonTitle, string cancelButtonTitle, UIDatePickerMode datePickerMode, Action<DateTime> callback, DateTime defaultDate, DateTime? maximumDate=null, DateTime? minimumDate= null)
         {
 
             _title = title;
@@ -50,6 +57,8 @@ namespace DT.iOS.DatePickerDialog
             _datePickerMode = datePickerMode;
             _callback = callback;
             _defaultDate = defaultDate;
+            _maximumDate = maximumDate;
+            _minimumDate = minimumDate;
 
             _dialogView = createContainerView();
 
@@ -177,6 +186,13 @@ namespace DT.iOS.DatePickerDialog
             _datePicker.Frame = new CGRect(_datePicker.Frame.Location, new CGSize(300, _datePicker.Frame.Size.Height));
             _datePicker.Mode = _datePickerMode;
             _datePicker.Date = (NSDate)_defaultDate;
+
+            if (_maximumDate.HasValue)
+                _datePicker.MaximumDate = (NSDate)_maximumDate.Value;
+
+            if (_minimumDate.HasValue)
+                _datePicker.MinimumDate = (NSDate)_minimumDate.Value;
+
             dialogContainer.AddSubview(_datePicker);
             AddButtonsToView(dialogContainer);
             return dialogContainer;

--- a/DT.iOS.DatePickerDialog/DatePickerDialog.cs
+++ b/DT.iOS.DatePickerDialog/DatePickerDialog.cs
@@ -38,9 +38,9 @@ namespace DT.iOS.DatePickerDialog
         {
         }
 
-        public void Show(String title, Action<DateTime> callback, DateTime maximumDate, DateTime minimumDate)
+        public void Show(String title, Action<DateTime> callback, DateTime minimumDate, DateTime maximumDate)
         {
-            Show(title, doneButtonTitle: "Done", cancelButtonTitle: "Cancel", datePickerMode: UIDatePickerMode.DateAndTime, callback: callback, defaultDate: DateTime.Now, maximumDate: maximumDate,minimumDate: minimumDate);
+            Show(title, doneButtonTitle: "Done", cancelButtonTitle: "Cancel", datePickerMode: UIDatePickerMode.DateAndTime, callback: callback, defaultDate: DateTime.Now, maximumDate: maximumDate, minimumDate: minimumDate);
         }
 
         public void Show(String title, Action<DateTime> callback, UIDatePickerMode datePickerMode = UIDatePickerMode.DateAndTime)

--- a/TestDialogApp/Main.storyboard
+++ b/TestDialogApp/Main.storyboard
@@ -1,7 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="NO" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <deployment identifier="iOS"/>
+        <development version="7000" identifier="xcode"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -42,15 +44,24 @@
                                     <action selector="DatePickerClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0Ek-Ip-JuU"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3">
+                                <rect key="frame" x="188" y="239" width="238" height="30"/>
+                                <state key="normal" title="Date picker with range"/>
+                                <connections>
+                                    <action selector="DatePickerWithDateRange:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7"/>
+                                </connections>
+                            </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstItem="eae-gT-nH8" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="26" id="54C-L7-OAM"/>
                             <constraint firstItem="khP-pX-dMY" firstAttribute="top" secondItem="eae-gT-nH8" secondAttribute="bottom" constant="32" id="G2A-XJ-95q"/>
                             <constraint firstItem="YOw-Lf-xXu" firstAttribute="top" secondItem="ooL-iy-dP8" secondAttribute="bottom" constant="15" id="GPO-z2-wkn"/>
+                            <constraint firstItem="3" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="OHk-pP-yAj"/>
                             <constraint firstItem="ooL-iy-dP8" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="R6E-1S-GbW"/>
                             <constraint firstItem="ooL-iy-dP8" firstAttribute="top" secondItem="khP-pX-dMY" secondAttribute="bottom" constant="26" id="SDG-MS-uVa"/>
                             <constraint firstItem="YOw-Lf-xXu" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="d1b-Yb-uHg"/>
+                            <constraint firstItem="3" firstAttribute="top" secondItem="YOw-Lf-xXu" secondAttribute="bottom" constant="15" id="efn-lq-KLx"/>
                             <constraint firstItem="khP-pX-dMY" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="ffM-ZD-Dor"/>
                             <constraint firstItem="eae-gT-nH8" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="wuP-DI-TlX"/>
                         </constraints>
@@ -62,6 +73,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="0.0" y="0.0"/>
         </scene>
     </scenes>
 </document>

--- a/TestDialogApp/Main.storyboard
+++ b/TestDialogApp/Main.storyboard
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="NO" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
         <development version="7000" identifier="xcode"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -46,7 +47,7 @@
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3">
                                 <rect key="frame" x="188" y="239" width="238" height="30"/>
-                                <state key="normal" title="Date picker with range"/>
+                                <state key="normal" title="Date picker with range (day+1)"/>
                                 <connections>
                                     <action selector="DatePickerWithDateRange:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7"/>
                                 </connections>

--- a/TestDialogApp/ViewController.cs
+++ b/TestDialogApp/ViewController.cs
@@ -36,9 +36,9 @@ namespace TestDialogApp
             var startingTime = DateTime.Now;
             var dialog = new DatePickerDialog();
             dialog.Show("Choose time", (dt) =>
-                {
-                    TimePickLabel.Text = dt.ToString();
-            },DateTime.Now.AddDays(10), DateTime.Now.AddDays(-10));
+            {
+                TimePickLabel.Text = dt.ToString();
+            }, DateTime.Now, DateTime.Now.AddDays(1));
         }
     }
 }

--- a/TestDialogApp/ViewController.cs
+++ b/TestDialogApp/ViewController.cs
@@ -30,6 +30,16 @@ namespace TestDialogApp
                     TimePickLabel.Text = dt.ToString();
                 }, startingTime);
         }
+
+        partial void DatePickerWithDateRange(UIButton sender)
+        {
+            var startingTime = DateTime.Now;
+            var dialog = new DatePickerDialog();
+            dialog.Show("Choose time", (dt) =>
+                {
+                    TimePickLabel.Text = dt.ToString();
+            },DateTime.Now.AddDays(10), DateTime.Now.AddDays(-10));
+        }
     }
 }
 

--- a/TestDialogApp/ViewController.designer.cs
+++ b/TestDialogApp/ViewController.designer.cs
@@ -1,40 +1,48 @@
 // WARNING
 //
-// This file has been generated automatically by Xamarin Studio to store outlets and
-// actions made in the UI designer. If it is removed, they will be lost.
-// Manual changes to this file may not be handled correctly.
+// This file has been generated automatically by Xamarin Studio from the outlets and
+// actions declared in your storyboard file.
+// Manual changes to this file will not be maintained.
 //
 using Foundation;
+using System;
 using System.CodeDom.Compiler;
 
 namespace TestDialogApp
 {
-	[Register ("ViewController")]
-	partial class ViewController
-	{
-		[Outlet]
-		UIKit.UILabel DatePickLabel { get; set; }
+    [Register ("ViewController")]
+    partial class ViewController
+    {
+        [Outlet]
+        UIKit.UILabel DatePickLabel { get; set; }
 
-		[Outlet]
-		UIKit.UILabel TimePickLabel { get; set; }
 
-		[Action ("DatePickerClicked:")]
-		partial void DatePickerClicked (Foundation.NSObject sender);
+        [Outlet]
+        UIKit.UILabel TimePickLabel { get; set; }
 
-		[Action ("TimePickerClicked:")]
-		partial void TimePickerClicked (Foundation.NSObject sender);
-		
-		void ReleaseDesignerOutlets ()
-		{
-			if (TimePickLabel != null) {
-				TimePickLabel.Dispose ();
-				TimePickLabel = null;
-			}
 
-			if (DatePickLabel != null) {
-				DatePickLabel.Dispose ();
-				DatePickLabel = null;
-			}
-		}
-	}
+        [Action ("DatePickerClicked:")]
+        partial void DatePickerClicked (Foundation.NSObject sender);
+
+
+        [Action ("TimePickerClicked:")]
+        partial void TimePickerClicked (Foundation.NSObject sender);
+
+        [Action ("DatePickerWithDateRange:")]
+        [GeneratedCode ("iOS Designer", "1.0")]
+        partial void DatePickerWithDateRange (UIKit.UIButton sender);
+
+        void ReleaseDesignerOutlets ()
+        {
+            if (DatePickLabel != null) {
+                DatePickLabel.Dispose ();
+                DatePickLabel = null;
+            }
+
+            if (TimePickLabel != null) {
+                TimePickLabel.Dispose ();
+                TimePickLabel = null;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Made changes to accommodate date range in the calendar control. So with this pull request, we can restrict the date range for validation purpose.   

Example:
Here i have added date range from today to till tomorrow (day+1, i.e mindate: DateTime.Now - maxdate: DateTime.Now.AddDays(1)) 
![2017-06-03_09-32-23](https://cloud.githubusercontent.com/assets/3939201/26750449/2c41dfd2-4840-11e7-963b-f68e9d1fde19.gif)
